### PR TITLE
event loop stops when it receives malformed JSON string

### DIFF
--- a/lib/AnyEvent/FriendFeed/Realtime.pm
+++ b/lib/AnyEvent/FriendFeed/Realtime.pm
@@ -38,7 +38,9 @@ sub new {
         }, sub {
             my($body, $headers) = @_;
             return $long_poll->() unless $body;
-            my $res = JSON::decode_json($body);
+
+            my $res = eval { JSON::decode_json($body) };
+            return $long_poll->() if $@;
 
             if ($res->{errorCode}) {
                 ($args{on_error} || sub { die @_ })->($res->{errorCode});

--- a/xt/podspell.t
+++ b/xt/podspell.t
@@ -7,3 +7,7 @@ all_pod_files_spelling_ok('lib');
 __DATA__
 Tatsuhiko
 Miyagawa
+API
+AnyEvent
+FriendFeed
+JSON


### PR DESCRIPTION
I encountered an error that "EV: error in callback (ignoring): malformed JSON string, (...snip...) perlbrew/perls/perl-5.12.1/lib/site_perl/5.12.1/AnyEvent/FriendFeed/Realtime.pm line 41."

So I added catching exception process when the body is malformed json.
