### PR TITLE
catch the exception from JSON.pm

### DIFF
--- a/lib/AnyEvent/FriendFeed/Realtime.pm
+++ b/lib/AnyEvent/FriendFeed/Realtime.pm
@@ -38,7 +38,10 @@ sub new {
         }, sub {
             my($body, $headers) = @_;
             return $long_poll->() unless $body;
-            my $res = JSON::decode_json($body);
+            my $res = eval { JSON::decode_json($body) } || do {
+                ($args{on_error} || sub { die @_ })->("JSON parsing error: $@");
+                return;
+            };
 
             if ($res->{errorCode}) {
                 ($args{on_error} || sub { die @_ })->($res->{errorCode});


### PR DESCRIPTION
Friendfeed returns malformed JSON string at sometime. It breaks poller script.
The error should be catch and pass it to 'on_error' handler.
